### PR TITLE
Adjust dropdown left position for overflow handling

### DIFF
--- a/src/lib/util/dropdown.ts
+++ b/src/lib/util/dropdown.ts
@@ -12,8 +12,16 @@ export function getDropdownPosition(
         getInputSelectionStart(input)
     );
 
-    // Is there place for the dropdown below the caret?
+    // Calculate base positioning
     const inputRect = input.getBoundingClientRect();
+    const baseLeft = left + input.offsetLeft + DROPDOWN_MARGIN;
+    
+    // Check for horizontal overflow and adjust if necessary
+    const adjustedLeft = baseLeft + DROPDOWN_WIDTH > window.innerWidth
+        ? window.innerWidth - DROPDOWN_WIDTH - DROPDOWN_MARGIN
+        : baseLeft;
+
+    // Is there place for the dropdown below the caret?
     if (
         inputRect.top + top + dropdownHeight + 2 * DROPDOWN_MARGIN <=
         window.innerHeight
@@ -21,7 +29,7 @@ export function getDropdownPosition(
         return {
             toTop: false,
             top: top + input.offsetTop + DROPDOWN_MARGIN,
-            left: left + input.offsetLeft + DROPDOWN_MARGIN,
+            left: adjustedLeft,
             width: DROPDOWN_WIDTH,
             height: dropdownHeight,
         };
@@ -32,7 +40,7 @@ export function getDropdownPosition(
         return {
             toTop: true,
             top: top + input.offsetTop - dropdownHeight - DROPDOWN_MARGIN,
-            left: left + input.offsetLeft + DROPDOWN_MARGIN,
+            left: adjustedLeft,
             width: DROPDOWN_WIDTH,
             height: dropdownHeight,
         };
@@ -41,7 +49,7 @@ export function getDropdownPosition(
     return {
         toTop: true,
         top: input.offsetTop - inputRect.top + DROPDOWN_MARGIN,
-        left: left + input.offsetLeft + DROPDOWN_MARGIN,
+        left: adjustedLeft,
         width: DROPDOWN_WIDTH,
         height: window.innerHeight - 2 * DROPDOWN_MARGIN,
     };


### PR DESCRIPTION
Fixes position of the dropdown when the screen is too narrow and it would overflow the page.

NOW
<img width="948" height="382" alt="image" src="https://github.com/user-attachments/assets/98132475-454c-4039-8246-e1f3a32cffb1" />


BEFORE
<img width="944" height="384" alt="image" src="https://github.com/user-attachments/assets/e32e70c8-50e6-4fc4-b2b1-7e6d3b3afbc3" />
