### PR TITLE
Add input window left offset

### DIFF
--- a/src/lib/util/dropdown.ts
+++ b/src/lib/util/dropdown.ts
@@ -17,8 +17,8 @@ export function getDropdownPosition(
     const baseLeft = left + input.offsetLeft + DROPDOWN_MARGIN;
     
     // Check for horizontal overflow and adjust if necessary
-    const adjustedLeft = baseLeft + DROPDOWN_WIDTH > window.innerWidth
-        ? window.innerWidth - DROPDOWN_WIDTH - DROPDOWN_MARGIN
+    const adjustedLeft = baseLeft + inputRect.left + DROPDOWN_WIDTH > window.innerWidth
+        ? inputRect.width - DROPDOWN_WIDTH - DROPDOWN_MARGIN
         : baseLeft;
 
     // Is there place for the dropdown below the caret?


### PR DESCRIPTION
Follow up of https://github.com/7PH/vue-smart-suggest/pull/7

Fixes an edge case when the input is positioned to the right itself.

NOW
<img width="1386" height="420" alt="image" src="https://github.com/user-attachments/assets/42f6310c-ef66-4d34-a8fb-063ed6d05d66" />


BEFORE
<img width="1408" height="436" alt="image" src="https://github.com/user-attachments/assets/5e7404cf-5db0-48e2-aecc-69e007c20d93" />
